### PR TITLE
Use site-maven-plugin to create github mvn-repo branch as repository for...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,9 +6,9 @@
 	<version>0.1.1</version>
 	<packaging>bundle</packaging>
 	<properties>
+		<github.global.server>github</github.global.server>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<spring.version>3.0.0.RELEASE</spring.version>
-		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 	</properties>
 	<dependencies>
 		<!-- compile and runtime dependencies -->
@@ -65,8 +65,6 @@
 			<groupId>org.jscience</groupId>
 			<artifactId>jscience</artifactId>
 			<version>4.3.1</version>
-			<scope>system</scope>
-			<systemPath>${project.basedir}/lib/jscience-4.3.1.jar</systemPath>
 		</dependency>
 	</dependencies>
 	<repositories>
@@ -90,9 +88,47 @@
 			<name>SpringSource Enterprise Bundle Repository - External Library Releases</name>
 			<url>http://repository.springsource.com/maven/libraries/external</url>
 		</repository>
+		<repository>
+			<id>org.geppetto.core-mvn-repo</id>
+			<url>https://raw.github.com/${my.github.username}/org.geppetto.core/mvn-repo</url>
+			<snapshots>
+				<enabled>true</enabled>
+				<updatePolicy>always</updatePolicy>
+			</snapshots>
+		</repository>
 	</repositories>
+	<distributionManagement>
+		<repository>
+			<id>internal.repo</id>
+			<name>Temporary Staging Repository</name>
+			<url>file://${project.build.directory}/mvn-repo</url>
+		</repository>
+	</distributionManagement>
 	<build>
 		<plugins>
+			<plugin>
+				<groupId>com.github.github</groupId>
+				<artifactId>site-maven-plugin</artifactId>
+				<version>0.9</version>
+				<configuration>
+					<message>Maven artifacts for ${project.version}</message>  <!-- git commit message -->
+					<noJekyll>true</noJekyll>                                  <!-- disable webpage processing -->
+					<outputDirectory>${project.build.directory}/mvn-repo</outputDirectory> <!-- matches distribution management repository url -->
+					<branch>refs/heads/mvn-repo</branch>                       <!-- remote branch name -->
+					<includes><include>**/*</include></includes>
+					<repositoryName>org.geppetto.core</repositoryName>      <!-- github repo name -->
+					<repositoryOwner>${my.github.username}</repositoryOwner>    <!-- github username  -->
+				</configuration>
+				<executions>
+					<!-- run site-maven-plugin's 'site' target as part of the build's normal 'deploy' phase -->
+					<execution>
+						<goals>
+							<goal>site</goal>
+						</goals>
+						<phase>deploy</phase>
+					</execution>
+				</executions>
+			</plugin>
 			<plugin>
 				<groupId>com.googlecode.jsonschema2pojo</groupId>
 				<artifactId>jsonschema2pojo-maven-plugin</artifactId>
@@ -144,7 +180,7 @@
 					<instructions>
 						<Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
 						<Bundle-Version>${project.version}</Bundle-Version>
-						<Bundle-ClassPath>.,{maven-dependencies},lib/jscience-4.3.1.jar</Bundle-ClassPath>
+						<Bundle-ClassPath>.,{maven-dependencies}</Bundle-ClassPath>
  						<Export-Package>org.geppetto.core.*,org.jscience.*, javolution.*, org.opengis.*, javax.measure.*, javax.realtime.*,</Export-Package>
 					</instructions>
 				</configuration>


### PR DESCRIPTION
... jars

When "mvn deploy" is run, jars are pushed to a special branch called "mvn-repo"

To use, you need to configure ~/.m2/settings.xml as follows:

```
<settings>
    <servers>
        <server>
            <id>github</id>
            <username>[your username]</username>
            <password>[your pw]</password>
        </server>
    </servers>
    <properties>
        <my.github.username>[your username]</my.github.username>
    </properties>
</settings>
```
