### PR TITLE
Conversion services

### DIFF
--- a/src/main/resources/schema/simulation/simulationSchema.xsd
+++ b/src/main/resources/schema/simulation/simulationSchema.xsd
@@ -5,6 +5,23 @@
 	jxb:version="2.0">
 
 
+	<element name="simulation">
+		<complexType>
+			<sequence>
+				<element name="entity" type="tns:Entity" maxOccurs="unbounded"
+					minOccurs="1">
+					<annotation>
+						<appinfo>
+							<jxb:property name="entities" />
+						</appinfo>
+					</annotation>
+				</element>
+				<element name="script" type="string" maxOccurs="unbounded"
+					minOccurs="0"></element>
+			</sequence>
+		</complexType>
+	</element>
+
 	<complexType name="Model">
 		<sequence>
 			<element name="modelInterpreterId" type="string" maxOccurs="1"
@@ -89,10 +106,10 @@
 		<sequence>
 			<element name="id" type="string" maxOccurs="1" minOccurs="1"></element>
 			<element name="instancePath" type="string" maxOccurs="1" minOccurs="0"></element>
-			<element name="model" type="tns:Model" maxOccurs="1"
-				minOccurs="1"></element>
 			<element name="simulator" type="tns:Simulator" maxOccurs="1"
 				minOccurs="0"></element>
+			<element name="model" type="tns:Model" maxOccurs="1"
+				minOccurs="1"></element>
 			<element name="parentEntity" type="tns:Entity" maxOccurs="1" minOccurs="0"></element>
 		</sequence>
 	</complexType>
@@ -163,20 +180,5 @@
 		</sequence>
 	</complexType>
 
-	<element name="simulation">
-		<complexType>
-			<sequence>
-				<element name="entity" type="tns:Entity" maxOccurs="unbounded"
-					minOccurs="1">
-					<annotation>
-						<appinfo>
-							<jxb:property name="entities" />
-						</appinfo>
-					</annotation>
-				</element>
-				<element name="script" type="string" maxOccurs="unbounded"
-					minOccurs="0"></element>
-			</sequence>
-		</complexType>
-	</element>
+	
 </schema>

--- a/src/main/resources/schema/simulation/simulationSchema.xsd
+++ b/src/main/resources/schema/simulation/simulationSchema.xsd
@@ -25,6 +25,8 @@
 				minOccurs="0"></element>
 			<element name="instancePath" type="string" maxOccurs="1" minOccurs="0"></element>
 			<element name="parentAspect" type="tns:Aspect" maxOccurs="1" minOccurs="0"></element>
+			<element name="conversionServiceId" type="string" maxOccurs="1"
+				minOccurs="0"></element>
 		</sequence>
 	</complexType>
 


### PR DESCRIPTION
@tarelli have a look at the schema I am commiting in this PR. I have moved up this tag in the aspect node: ```<element name="simulator" type="tns:Simulator" maxOccurs="1" minOccurs="0"></element>```.  I had to do this otherwise all the GEPPETTO.xml simulation files that can be found in org.geppetto.samples are not valid since we are now validating this file when unmarshalling (I am creating a PR for org.geppetto.simulation that implements this validation). This is due to the fact that we are using the ```<sequence>``` tag which means that elements inside this tag will appear in this specific order. I have checked all the GEPPETTO.xml in the org.geppetto.samples and the aspect element has the children in this order: id, simulator (if it has a simulator) and model. Therefore, there shouldn't be any problem with this schema validation code. 