### PR TITLE
Commenting jaxb force rebuild: causes endless-build loop in Eclipse. 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
 							<bindingIncludes>
 								<include>simulationSchema.xjb</include>
 							</bindingIncludes>
-							<forceRegenerate>true</forceRegenerate>
+							<!--<forceRegenerate>true</forceRegenerate>-->
 							<schemaDirectory>src/main/resources/schema/simulation</schemaDirectory>
 							<generateDirectory>${project.build.directory}/generated-sources/simulationSchema</generateDirectory>
 							<schemaIncludes>


### PR DESCRIPTION
@tarelli it fixes it for me in Luna, and apparently for @adrianq in Juno.
SPH also needs to be updated accordingly.