### PR TITLE
Dropbox v2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 		<dependency>
 			<groupId>com.dropbox.core</groupId>
 			<artifactId>dropbox-core-sdk</artifactId>
-			<version>1.7.7</version>
+			<version>3.0.5</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>jackson-core</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
 		<dependency>
 			<groupId>com.dropbox.core</groupId>
 			<artifactId>dropbox-core-sdk</artifactId>
-			<version>3.0.5</version>
+			<version>3.0.6-SNAPSHOT</version>
 			<exclusions>
 				<exclusion>
 					<artifactId>jackson-core</artifactId>
@@ -151,17 +151,17 @@
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-core</artifactId>
-			<version>2.5.3</version>
+			<version>2.7.4</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-annotations</artifactId>
-			<version>2.5.3</version>
+			<version>2.7.4</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>
 			<artifactId>jackson-databind</artifactId>
-			<version>2.5.3</version>
+			<version>2.7.4</version>
 		</dependency>
 		<dependency>
 			<groupId>uk.com.robust-it</groupId>

--- a/src/main/java/org/geppetto/core/manager/IDropBoxManager.java
+++ b/src/main/java/org/geppetto/core/manager/IDropBoxManager.java
@@ -11,6 +11,7 @@ import com.dropbox.core.DbxException;
 
 public interface IDropBoxManager
 {
+    public abstract String getDropboxToken() throws Exception;
 
 	/**
 	 * Link the user dropbox account with the geppetto account

--- a/src/main/java/org/geppetto/core/services/DropboxUploadService.java
+++ b/src/main/java/org/geppetto/core/services/DropboxUploadService.java
@@ -15,7 +15,8 @@ import com.dropbox.core.v2.files.WriteMode;
 import com.dropbox.core.v2.files.FileMetadata;
 import com.dropbox.core.DbxException;
 import com.dropbox.core.DbxRequestConfig;
-import com.dropbox.core.DbxWebAuthNoRedirect;
+import com.dropbox.core.DbxRequestConfig.Builder;
+import com.dropbox.core.DbxWebAuth;
 
 
 /**
@@ -30,9 +31,9 @@ public class DropboxUploadService implements IExternalUploadService
 	final String APP_KEY = "kbved8e6wnglk4h";
 	final String APP_SECRET = "3vfszva2y4ax7j5";
 	private String authorizeURL = null;
-	private DbxWebAuthNoRedirect webAuth = null;
+	private DbxWebAuth webAuth = null;
 	private DbxRequestConfig config = null;
-        private DbxClientV2 client = null;
+    private DbxClientV2 client = null;
 
 	private static Log logger = LogFactory.getLog(DropboxUploadService.class);
 
@@ -46,10 +47,15 @@ public class DropboxUploadService implements IExternalUploadService
 
 		DbxAppInfo appInfo = new DbxAppInfo(APP_KEY, APP_SECRET);
 
-		config = new DbxRequestConfig("Geppetto", Locale.getDefault().toString());
-		webAuth = new DbxWebAuthNoRedirect(config, appInfo);
+		config = DbxRequestConfig.newBuilder("Geppetto")
+				.withUserLocale(Locale.getDefault().toString())
+				.build();
 
-		authorizeURL = webAuth.start();
+		webAuth = new DbxWebAuth(config, appInfo);
+        DbxWebAuth.Request webAuthRequest = DbxWebAuth.newRequestBuilder()
+            .withNoRedirect()
+            .build();
+		authorizeURL = webAuth.authorize(webAuthRequest);
 
 	}
 
@@ -97,7 +103,7 @@ public class DropboxUploadService implements IExternalUploadService
 	{
 		try
 		{
-			DbxAuthFinish authFinish = webAuth.finish(code);
+			DbxAuthFinish authFinish = webAuth.finishFromCode(code);
 
 			String accessToken = authFinish.getAccessToken();
 


### PR DESCRIPTION
the old dropbox API is no longer supported. I'm still testing this but it seems to work. Opening pull request now mainly so I can make a note of the black magic that was required to get virgo to boot:

- clone https://github.com/justinedelson/dropbox-sdk-java 
- checkout branch `feature/better-osgi-citizen`
- `./update-submodules.sh`
- `sudo -H python -m pip install ply six typing`
- apply [this diff](https://gist.github.com/mattearnshaw/10f02a16415eeb38c46e3a587f1121ed)
- `./gradlew -Posgi.bnd.noee=true jar`
- `./gradlew install`